### PR TITLE
Stack Variables Improvements

### DIFF
--- a/GTAdhocCompiler/AdhocCodeGen.cs
+++ b/GTAdhocCompiler/AdhocCodeGen.cs
@@ -101,8 +101,8 @@ namespace GTAdhocCompiler
                 stream.WriteInt32(block.Stack.StackSize);
 
                 /* These two are combined to make the size of the storage for variables */
-                stream.WriteInt32(block.Stack.LocalVariableStorageSize + block.Stack.StaticVariableStorageSize);
-                stream.WriteInt32(0);
+                stream.WriteInt32(block.Stack.LocalVariableStorageSize);
+                stream.WriteInt32(block.Stack.StaticVariableStorageSize);
             }
 
             stream.WriteInt32(block.Instructions.Count);

--- a/GTAdhocCompiler/AdhocScriptCompiler.cs
+++ b/GTAdhocCompiler/AdhocScriptCompiler.cs
@@ -647,7 +647,7 @@ namespace GTAdhocCompiler
             InsertAssignPop(frame);
 
             LocalVariable caseVariable = frame.Stack.GetLocalVariableBySymbol(labelSymb);
-            int caseVariableStoreIdx = frame.Stack.GetGlobalVariableIndex(caseVariable);
+            int caseVariableStoreIdx = frame.Stack.GetLocalVariableIndex(caseVariable);
 
             Dictionary<SwitchCase, InsJumpIfTrue> caseBodyJumps = new();
             InsJump defaultJump = null;
@@ -1262,7 +1262,8 @@ namespace GTAdhocCompiler
 
             if (expStatement.Expression.Type != Nodes.AssignmentExpression
                 && expStatement.Expression.Type != Nodes.StaticDeclaration
-                && expStatement.Expression.Type != Nodes.AttributeDeclaration)
+                && expStatement.Expression.Type != Nodes.AttributeDeclaration
+                && expStatement.Expression.Type != Nodes.YieldExpression)
                 frame.AddInstruction(InsPop.Default, 0); // Discard any result
         }
 
@@ -2244,7 +2245,7 @@ namespace GTAdhocCompiler
                 }
                 else
                 {
-                    leave.VariableStorageRewindIndex = frame.Stack.GetLastVariableStorageIndex();
+                    leave.VariableStorageRewindIndex = frame.Stack.GetLastLocalVariableIndex();
                 }
 
                 frame.AddInstruction(leave, 0);


### PR DESCRIPTION
Fixes how the variable storages are handled.
Starting Adhoc version `11` (around GTHD) the variable storage is divided in two parts:
* Local Variables
* Static Variables

Until now we treated it as one single storage, which worked fine until we encounted `METHOD_CONST`'s.
`VARIABLE_PUSH` and `VARIABLE_EVAL`'s will use a duplicate symbol when refering to a static, or local variable.

For instance:
```
VARIABLE_EVAL: context, Index:1
```
Will refer to local variable storage index 1 whereas
```
VARIABLE_EVAL: CourseRoot,CourseRoot, Index:1
```
Will refer to static variable storage index 1.

This PR removes the concept of using one single storage and properly uses two as intended. Note: This may cause problems later on if we are going to start GT4 as it uses one single storage, but for now we don't need it.

(Also fixes a minor issue where yield statements would be `POP`'ed.)
